### PR TITLE
Fix CMake troubles on i386

### DIFF
--- a/libc/i386/CMakeLists.txt
+++ b/libc/i386/CMakeLists.txt
@@ -19,6 +19,6 @@ set(i386_sources
 	gen/_setcontext.S
 )
 
-add_library(libc-i386 OBJECT ${i386_sources})
+add_library(libc-hwplat OBJECT ${i386_sources})
 
 

--- a/libc/sys/CMakeLists.txt
+++ b/libc/sys/CMakeLists.txt
@@ -30,7 +30,7 @@ set(sys_sources chmodx_np.c
 )
 
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
-	set(sys_sources ${sys_sources} context-stubs.cpp)
+	set(sys_sources ${sys_sources} context-stubs.c)
 endif()
 
 SET_SOURCE_FILES_PROPERTIES(semctl.c PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -DLIBC_ALIAS_SEMCTL -DKERNEL -U__DARWIN_UNIX03 -D__DARWIN_UNIX03=0")


### PR DESCRIPTION
Tested on i386, CMake fails.
It works with these patches.